### PR TITLE
Implements `per_page` in api request

### DIFF
--- a/bin/export-github-issues
+++ b/bin/export-github-issues
@@ -75,7 +75,8 @@ HERE
       options = { path: @output,
                   multiple_files: @multiple_files,
                   include_closed_issues: @include_closed_issues,
-                  output_type: @output_type }
+                  output_type: @output_type,
+                  page_size: true }
       exporter = IssueExporting::Exporter.new(@owner, @repo, @token, options)
       exporter.export
     end

--- a/lib/issue_exporter/github.rb
+++ b/lib/issue_exporter/github.rb
@@ -3,15 +3,14 @@ module IssueExporting
     "https://api.github.com/repos/%s/%s/issues?access_token=%s"
   end
 
-  def self.make_url(owner, repo, token, options = {})
+  def self.make_url(owner, repo, token)
     url_format = IssueExporting.api_url
     root_url = url_format % [owner, repo, token]
-    return root_url unless options[:include_closed_issues] == true
-    root_url + "&state=all"
+    return root_url 
   end
 
-  def self.make_uri(owner, repo, token, options = {})
-    URI(IssueExporting.make_url(owner, repo, token, options))
+  def self.make_uri(owner, repo, token)
+    URI(IssueExporting.make_url(owner, repo, token))
   end
 
   def self.turn_options_into_querystring(options)

--- a/lib/issue_exporter/version.rb
+++ b/lib/issue_exporter/version.rb
@@ -1,5 +1,5 @@
 # Copyright (c) 2015 Scott Williams
 
 module IssueExporting
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/github_url_spec.rb
+++ b/spec/github_url_spec.rb
@@ -1,17 +1,7 @@
 require 'spec_helper'
 
 describe 'URL Building' do
-  it 'builds a URL with the closed flag when present' do
-    url = IssueExporting.make_url 'herp', 'derp', 'TOKEN', { include_closed_issues: true }
-    expect(url).to eq "https://api.github.com/repos/herp/derp/issues?access_token=TOKEN&state=all"
-  end
-
-  it 'builds a URL without the closed flag when it is false' do
-    url = IssueExporting.make_url 'herp', 'derp', 'TOKEN', { include_closed_issues: false }
-    expect(url).to eq "https://api.github.com/repos/herp/derp/issues?access_token=TOKEN"
-  end
-
-  it 'builds a URL without the closed flag when it\'s missing' do
+  it 'builds a URL' do
     url = IssueExporting.make_url 'herp', 'derp', 'TOKEN'
     expect(url).to eq "https://api.github.com/repos/herp/derp/issues?access_token=TOKEN"
   end


### PR DESCRIPTION
This bumps the results to handle up to 100 issues (#10), which is currently the API limit from GitHub. A future version may include more [pagination support](https://developer.github.com/v3/#pagination).

No changes to the executable.